### PR TITLE
Implemented eda_numeric_columns and added test cases

### DIFF
--- a/datascience_eda/datascience_eda.py
+++ b/datascience_eda/datascience_eda.py
@@ -32,6 +32,9 @@ from collections import Counter
 
 # endregion
 
+# region import libraries for eda of numeric features
+import numpy as np
+import altair as alt
 # region support functions
 
 
@@ -831,10 +834,70 @@ def explore_numeric_columns(
 
     # Generate plots
 
-    results = (
-        []
-    )  # List will store plot objects created by this function to return to user
-    return results
+    if not (type(data) == pd.DataFrame):
+        raise TypeError("data must be passed as a DataFrame.")
+
+    if type(hist_cols)!=list and hist_cols!=None:
+        raise TypeError("hist_cols must be passed as a list.")
+
+    if type(pairplot_cols)!=list and pairplot_cols!=None:
+        raise TypeError("pairplot_cols must be passed as a list.")
+
+    if type(corr_method)!=str and corr_method!=None:
+        raise TypeError('corr_method must be passed as a str.')
+
+
+    cols = get_numeric_columns(data)
+
+
+    # Generate plots
+
+    plots = {} # Dictionary with results
+  
+    # Create histograms
+    histograms = []
+    cols = data.select_dtypes(include=np.number).columns.tolist()
+    if hist_cols==None: 
+        for col in cols:
+            chart = alt.Chart(data).encode(alt.X(col),alt.Y('count()')).mark_bar()
+            plt.figure()
+            print(chart)
+            histograms.append(chart)
+    else:
+        _verify_numeric_cols(data, hist_cols)
+        for col in hist_cols:
+            chart = alt.Chart(data).encode(alt.X(col),alt.Y('count()')).mark_bar()
+            plt.figure()
+            print(chart)
+            histograms.append(chart)
+    
+    plots['hist'] = histograms
+    
+    
+    # Create pairplots
+    if pairplot_cols == None:
+        chart = sns.pairplot(data)
+        plt.figure()
+        print(chart)
+        plots['pairplot'] = chart
+    else:
+        _verify_numeric_cols(data, pairplot_cols)  # Check that each column passed is numeric
+        chart = sns.pairplot(data, vars=pairplot_cols)
+        plt.figure()
+        print(chart)
+        plots['pairplot'] = chart
+        
+        
+    # Show heatmap with correlation coefficient
+    if corr_method not in [None, 'pearson', 'spearman', 'kendall']:
+        raise ValueError(f"Value for input 'corr_method' should be either None, 'pearson', 'spearman' or 'kendall'. '{corr_method}' was provided.")
+    chart = sns.heatmap(data.corr(method=corr_method), cmap='coolwarm', center=0)
+    plt.figure()
+    print(chart)
+    plots['corr'] = chart
+    
+    return plots
+
 
 
 def explore_categorical_columns(df, categorical_cols):

--- a/datascience_eda/datascience_eda.py
+++ b/datascience_eda/datascience_eda.py
@@ -859,14 +859,14 @@ def explore_numeric_columns(
     cols = data.select_dtypes(include=np.number).columns.tolist()
     if hist_cols==None: 
         for col in cols:
-            chart = alt.Chart(data).encode(alt.X(col),alt.Y('count()')).mark_bar()
+            chart = alt.Chart(data).encode(alt.X(col),alt.Y('count()')).mark_bar().properties(title='Histogram for '+col)
             plt.figure()
             print(chart)
             histograms.append(chart)
     else:
         _verify_numeric_cols(data, hist_cols)
         for col in hist_cols:
-            chart = alt.Chart(data).encode(alt.X(col),alt.Y('count()')).mark_bar()
+            chart = alt.Chart(data).encode(alt.X(col),alt.Y('count()')).mark_bar().properties(title='Histogram for '+col)
             plt.figure()
             print(chart)
             histograms.append(chart)
@@ -877,12 +877,14 @@ def explore_numeric_columns(
     # Create pairplots
     if pairplot_cols == None:
         chart = sns.pairplot(data)
+        chart.fig.suptitle("Pairplot between numeric features", y=1.08)
         plt.figure()
         print(chart)
         plots['pairplot'] = chart
     else:
         _verify_numeric_cols(data, pairplot_cols)  # Check that each column passed is numeric
         chart = sns.pairplot(data, vars=pairplot_cols)
+        chart.fig.suptitle("Pairplot between numeric features", y=1.08)
         plt.figure()
         print(chart)
         plots['pairplot'] = chart
@@ -892,6 +894,7 @@ def explore_numeric_columns(
     if corr_method not in [None, 'pearson', 'spearman', 'kendall']:
         raise ValueError(f"Value for input 'corr_method' should be either None, 'pearson', 'spearman' or 'kendall'. '{corr_method}' was provided.")
     chart = sns.heatmap(data.corr(method=corr_method), cmap='coolwarm', center=0)
+    plt.title("Heatmap showing correlation between numeric features")
     plt.figure()
     print(chart)
     plots['corr'] = chart

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,25 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "altair"
+version = "4.1.0"
+description = "Altair: A declarative statistical visualization library for Python."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+entrypoints = "*"
+jinja2 = "*"
+jsonschema = "*"
+numpy = "*"
+pandas = ">=0.18"
+toolz = "*"
+
+[package.extras]
+dev = ["black", "docutils", "ipython", "flake8", "pytest", "sphinx", "m2r", "vega-datasets", "recommonmark"]
+
+[[package]]
 name = "appnope"
 version = "0.1.2"
 description = "Disable App Nap on macOS >= 10.9"
@@ -180,7 +199,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "5.4"
+version = "5.5"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -276,7 +295,6 @@ spacy = ">=3.0.0,<3.1.0"
 [package.source]
 type = "url"
 url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.0.0/en_core_web_md-3.0.0.tar.gz"
-
 [[package]]
 name = "entrypoints"
 version = "0.3"
@@ -311,7 +329,7 @@ smmap = ">=3.0.1,<4"
 
 [[package]]
 name = "gitpython"
-version = "3.1.13"
+version = "3.1.14"
 description = "Python Git Library"
 category = "dev"
 optional = false
@@ -579,7 +597,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "keyring"
-version = "22.0.1"
+version = "22.3.0"
 description = "Store and access your passwords safely."
 category = "dev"
 optional = false
@@ -592,7 +610,7 @@ SecretStorage = {version = ">=3.2", markers = "sys_platform == \"linux\""}
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "pytest-black (>=0.3.7)", "pytest-mypy"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [[package]]
 name = "kiwisolver"
@@ -742,7 +760,7 @@ regex = "*"
 tqdm = "*"
 
 [package.extras]
-all = ["gensim", "numpy", "pyparsing", "python-crfsuite", "scipy", "twython", "requests", "scikit-learn", "matplotlib"]
+all = ["gensim", "requests", "numpy", "scikit-learn", "scipy", "python-crfsuite", "matplotlib", "pyparsing", "twython"]
 corenlp = ["requests"]
 machine_learning = ["gensim", "numpy", "python-crfsuite", "scikit-learn", "scipy"]
 plot = ["matplotlib"]
@@ -805,7 +823,7 @@ pyparsing = ">=2.0.2"
 
 [[package]]
 name = "pandas"
-version = "1.2.2"
+version = "1.2.3"
 description = "Powerful data structures for data analysis, time series, and statistics"
 category = "main"
 optional = false
@@ -876,7 +894,7 @@ python-versions = "*"
 
 [[package]]
 name = "pillow"
-version = "8.1.0"
+version = "8.1.1"
 description = "Python Imaging Library (Fork)"
 category = "main"
 optional = false
@@ -1324,7 +1342,7 @@ python-versions = "*"
 
 [[package]]
 name = "setuptools-scm"
-version = "5.0.1"
+version = "5.0.2"
 description = "the blessed package to manage your versions by scm tags"
 category = "dev"
 optional = false
@@ -1659,6 +1677,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "toolz"
+version = "0.11.1"
+description = "List processing tools and functional utilities"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "tornado"
 version = "6.1"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
@@ -1668,7 +1694,7 @@ python-versions = ">= 3.5"
 
 [[package]]
 name = "tqdm"
-version = "4.57.0"
+version = "4.59.0"
 description = "Fast, Extensible Progress Meter"
 category = "main"
 optional = false
@@ -1676,6 +1702,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 
 [package.extras]
 dev = ["py-make (>=0.1.0)", "twine", "wheel"]
+notebook = ["ipywidgets (>=6)"]
 telegram = ["requests"]
 
 [[package]]
@@ -1806,12 +1833,16 @@ scipy = ">=1.0.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "3fcddb79586481b522368f5e282b66da1e6fc8ec7cebf84375537ee52beaf1b0"
+content-hash = "8dce61ae2d35c81aafb765d3e05f493b9f861bcf1b4cc30ad321f2de4f39c831"
 
 [metadata.files]
 alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
+]
+altair = [
+    {file = "altair-4.1.0-py3-none-any.whl", hash = "sha256:7748841a1bea8354173d1140bef6d3b58bea21d201f562528e9599ea384feb7f"},
+    {file = "altair-4.1.0.tar.gz", hash = "sha256:3edd30d4f4bb0a37278b72578e7e60bc72045a8e6704179e2f4738e35bc12931"},
 ]
 appnope = [
     {file = "appnope-0.1.2-py2.py3-none-any.whl", hash = "sha256:93aa393e9d6c54c5cd570ccadd8edad61ea0c4b9ea7a01409020c9aa019eb442"},
@@ -1945,55 +1976,58 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
-    {file = "coverage-5.4-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:6d9c88b787638a451f41f97446a1c9fd416e669b4d9717ae4615bd29de1ac135"},
-    {file = "coverage-5.4-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:66a5aae8233d766a877c5ef293ec5ab9520929c2578fd2069308a98b7374ea8c"},
-    {file = "coverage-5.4-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9754a5c265f991317de2bac0c70a746efc2b695cf4d49f5d2cddeac36544fb44"},
-    {file = "coverage-5.4-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:fbb17c0d0822684b7d6c09915677a32319f16ff1115df5ec05bdcaaee40b35f3"},
-    {file = "coverage-5.4-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:b7f7421841f8db443855d2854e25914a79a1ff48ae92f70d0a5c2f8907ab98c9"},
-    {file = "coverage-5.4-cp27-cp27m-win32.whl", hash = "sha256:4a780807e80479f281d47ee4af2eb2df3e4ccf4723484f77da0bb49d027e40a1"},
-    {file = "coverage-5.4-cp27-cp27m-win_amd64.whl", hash = "sha256:87c4b38288f71acd2106f5d94f575bc2136ea2887fdb5dfe18003c881fa6b370"},
-    {file = "coverage-5.4-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:c6809ebcbf6c1049002b9ac09c127ae43929042ec1f1dbd8bb1615f7cd9f70a0"},
-    {file = "coverage-5.4-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ba7ca81b6d60a9f7a0b4b4e175dcc38e8fef4992673d9d6e6879fd6de00dd9b8"},
-    {file = "coverage-5.4-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:89fc12c6371bf963809abc46cced4a01ca4f99cba17be5e7d416ed7ef1245d19"},
-    {file = "coverage-5.4-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:4a8eb7785bd23565b542b01fb39115a975fefb4a82f23d407503eee2c0106247"},
-    {file = "coverage-5.4-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:7e40d3f8eb472c1509b12ac2a7e24158ec352fc8567b77ab02c0db053927e339"},
-    {file = "coverage-5.4-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1ccae21a076d3d5f471700f6d30eb486da1626c380b23c70ae32ab823e453337"},
-    {file = "coverage-5.4-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:755c56beeacac6a24c8e1074f89f34f4373abce8b662470d3aa719ae304931f3"},
-    {file = "coverage-5.4-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:322549b880b2d746a7672bf6ff9ed3f895e9c9f108b714e7360292aa5c5d7cf4"},
-    {file = "coverage-5.4-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:60a3307a84ec60578accd35d7f0c71a3a971430ed7eca6567399d2b50ef37b8c"},
-    {file = "coverage-5.4-cp35-cp35m-win32.whl", hash = "sha256:1375bb8b88cb050a2d4e0da901001347a44302aeadb8ceb4b6e5aa373b8ea68f"},
-    {file = "coverage-5.4-cp35-cp35m-win_amd64.whl", hash = "sha256:16baa799ec09cc0dcb43a10680573269d407c159325972dd7114ee7649e56c66"},
-    {file = "coverage-5.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:2f2cf7a42d4b7654c9a67b9d091ec24374f7c58794858bff632a2039cb15984d"},
-    {file = "coverage-5.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:b62046592b44263fa7570f1117d372ae3f310222af1fc1407416f037fb3af21b"},
-    {file = "coverage-5.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:812eaf4939ef2284d29653bcfee9665f11f013724f07258928f849a2306ea9f9"},
-    {file = "coverage-5.4-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:859f0add98707b182b4867359e12bde806b82483fb12a9ae868a77880fc3b7af"},
-    {file = "coverage-5.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:04b14e45d6a8e159c9767ae57ecb34563ad93440fc1b26516a89ceb5b33c1ad5"},
-    {file = "coverage-5.4-cp36-cp36m-win32.whl", hash = "sha256:ebfa374067af240d079ef97b8064478f3bf71038b78b017eb6ec93ede1b6bcec"},
-    {file = "coverage-5.4-cp36-cp36m-win_amd64.whl", hash = "sha256:84df004223fd0550d0ea7a37882e5c889f3c6d45535c639ce9802293b39cd5c9"},
-    {file = "coverage-5.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:1b811662ecf72eb2d08872731636aee6559cae21862c36f74703be727b45df90"},
-    {file = "coverage-5.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:6b588b5cf51dc0fd1c9e19f622457cc74b7d26fe295432e434525f1c0fae02bc"},
-    {file = "coverage-5.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:3fe50f1cac369b02d34ad904dfe0771acc483f82a1b54c5e93632916ba847b37"},
-    {file = "coverage-5.4-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:32ab83016c24c5cf3db2943286b85b0a172dae08c58d0f53875235219b676409"},
-    {file = "coverage-5.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:68fb816a5dd901c6aff352ce49e2a0ffadacdf9b6fae282a69e7a16a02dad5fb"},
-    {file = "coverage-5.4-cp37-cp37m-win32.whl", hash = "sha256:a636160680c6e526b84f85d304e2f0bb4e94f8284dd765a1911de9a40450b10a"},
-    {file = "coverage-5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:bb32ca14b4d04e172c541c69eec5f385f9a075b38fb22d765d8b0ce3af3a0c22"},
-    {file = "coverage-5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6c4d7165a4e8f41eca6b990c12ee7f44fef3932fac48ca32cecb3a1b2223c21f"},
-    {file = "coverage-5.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:a565f48c4aae72d1d3d3f8e8fb7218f5609c964e9c6f68604608e5958b9c60c3"},
-    {file = "coverage-5.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:fff1f3a586246110f34dc762098b5afd2de88de507559e63553d7da643053786"},
-    {file = "coverage-5.4-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:a839e25f07e428a87d17d857d9935dd743130e77ff46524abb992b962eb2076c"},
-    {file = "coverage-5.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:6625e52b6f346a283c3d563d1fd8bae8956daafc64bb5bbd2b8f8a07608e3994"},
-    {file = "coverage-5.4-cp38-cp38-win32.whl", hash = "sha256:5bee3970617b3d74759b2d2df2f6a327d372f9732f9ccbf03fa591b5f7581e39"},
-    {file = "coverage-5.4-cp38-cp38-win_amd64.whl", hash = "sha256:03ed2a641e412e42cc35c244508cf186015c217f0e4d496bf6d7078ebe837ae7"},
-    {file = "coverage-5.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:14a9f1887591684fb59fdba8feef7123a0da2424b0652e1b58dd5b9a7bb1188c"},
-    {file = "coverage-5.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:9564ac7eb1652c3701ac691ca72934dd3009997c81266807aef924012df2f4b3"},
-    {file = "coverage-5.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:0f48fc7dc82ee14aeaedb986e175a429d24129b7eada1b7e94a864e4f0644dde"},
-    {file = "coverage-5.4-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:107d327071061fd4f4a2587d14c389a27e4e5c93c7cba5f1f59987181903902f"},
-    {file = "coverage-5.4-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:0cdde51bfcf6b6bd862ee9be324521ec619b20590787d1655d005c3fb175005f"},
-    {file = "coverage-5.4-cp39-cp39-win32.whl", hash = "sha256:c67734cff78383a1f23ceba3b3239c7deefc62ac2b05fa6a47bcd565771e5880"},
-    {file = "coverage-5.4-cp39-cp39-win_amd64.whl", hash = "sha256:c669b440ce46ae3abe9b2d44a913b5fd86bb19eb14a8701e88e3918902ecd345"},
-    {file = "coverage-5.4-pp36-none-any.whl", hash = "sha256:c0ff1c1b4d13e2240821ef23c1efb1f009207cb3f56e16986f713c2b0e7cd37f"},
-    {file = "coverage-5.4-pp37-none-any.whl", hash = "sha256:cd601187476c6bed26a0398353212684c427e10a903aeafa6da40c63309d438b"},
-    {file = "coverage-5.4.tar.gz", hash = "sha256:6d2e262e5e8da6fa56e774fb8e2643417351427604c2b177f8e8c5f75fc928ca"},
+    {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:c2723d347ab06e7ddad1a58b2a821218239249a9e4365eaff6649d31180c1669"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:900fbf7759501bc7807fd6638c947d7a831fc9fdf742dc10f02956ff7220fa90"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c"},
+    {file = "coverage-5.5-cp27-cp27m-win32.whl", hash = "sha256:06191eb60f8d8a5bc046f3799f8a07a2d7aefb9504b0209aff0b47298333302a"},
+    {file = "coverage-5.5-cp27-cp27m-win_amd64.whl", hash = "sha256:7501140f755b725495941b43347ba8a2777407fc7f250d4f5a7d2a1050ba8e82"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:372da284cfd642d8e08ef606917846fa2ee350f64994bebfbd3afb0040436905"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:8963a499849a1fc54b35b1c9f162f4108017b2e6db2c46c1bed93a72262ed083"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:869a64f53488f40fa5b5b9dcb9e9b2962a66a87dab37790f3fcfb5144b996ef5"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:4a7697d8cb0f27399b0e393c0b90f0f1e40c82023ea4d45d22bce7032a5d7b81"},
+    {file = "coverage-5.5-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:8d0a0725ad7c1a0bcd8d1b437e191107d457e2ec1084b9f190630a4fb1af78e6"},
+    {file = "coverage-5.5-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:51cb9476a3987c8967ebab3f0fe144819781fca264f57f89760037a2ea191cb0"},
+    {file = "coverage-5.5-cp310-cp310-win_amd64.whl", hash = "sha256:c0891a6a97b09c1f3e073a890514d5012eb256845c451bd48f7968ef939bf4ae"},
+    {file = "coverage-5.5-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:3487286bc29a5aa4b93a072e9592f22254291ce96a9fbc5251f566b6b7343cdb"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:deee1077aae10d8fa88cb02c845cfba9b62c55e1183f52f6ae6a2df6a2187160"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:6c90e11318f0d3c436a42409f2749ee1a115cd8b067d7f14c148f1ce5574d701"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:30c77c1dc9f253283e34c27935fded5015f7d1abe83bc7821680ac444eaf7793"},
+    {file = "coverage-5.5-cp35-cp35m-win32.whl", hash = "sha256:9a1ef3b66e38ef8618ce5fdc7bea3d9f45f3624e2a66295eea5e57966c85909e"},
+    {file = "coverage-5.5-cp35-cp35m-win_amd64.whl", hash = "sha256:972c85d205b51e30e59525694670de6a8a89691186012535f9d7dbaa230e42c3"},
+    {file = "coverage-5.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:af0e781009aaf59e25c5a678122391cb0f345ac0ec272c7961dc5455e1c40066"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:74d881fc777ebb11c63736622b60cb9e4aee5cace591ce274fb69e582a12a61a"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:92b017ce34b68a7d67bd6d117e6d443a9bf63a2ecf8567bb3d8c6c7bc5014465"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:d636598c8305e1f90b439dbf4f66437de4a5e3c31fdf47ad29542478c8508bbb"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:41179b8a845742d1eb60449bdb2992196e211341818565abded11cfa90efb821"},
+    {file = "coverage-5.5-cp36-cp36m-win32.whl", hash = "sha256:040af6c32813fa3eae5305d53f18875bedd079960822ef8ec067a66dd8afcd45"},
+    {file = "coverage-5.5-cp36-cp36m-win_amd64.whl", hash = "sha256:5fec2d43a2cc6965edc0bb9e83e1e4b557f76f843a77a2496cbe719583ce8184"},
+    {file = "coverage-5.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:18ba8bbede96a2c3dde7b868de9dcbd55670690af0988713f0603f037848418a"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2910f4d36a6a9b4214bb7038d537f015346f413a975d57ca6b43bf23d6563b53"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:796c9c3c79747146ebd278dbe1e5c5c05dd6b10cc3bcb8389dfdf844f3ead638"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:53194af30d5bad77fcba80e23a1441c71abfb3e01192034f8246e0d8f99528f3"},
+    {file = "coverage-5.5-cp37-cp37m-win32.whl", hash = "sha256:184a47bbe0aa6400ed2d41d8e9ed868b8205046518c52464fde713ea06e3a74a"},
+    {file = "coverage-5.5-cp37-cp37m-win_amd64.whl", hash = "sha256:2949cad1c5208b8298d5686d5a85b66aae46d73eec2c3e08c817dd3513e5848a"},
+    {file = "coverage-5.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:217658ec7187497e3f3ebd901afdca1af062b42cfe3e0dafea4cced3983739f6"},
+    {file = "coverage-5.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1aa846f56c3d49205c952d8318e76ccc2ae23303351d9270ab220004c580cfe2"},
+    {file = "coverage-5.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:24d4a7de75446be83244eabbff746d66b9240ae020ced65d060815fac3423759"},
+    {file = "coverage-5.5-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d1f8bf7b90ba55699b3a5e44930e93ff0189aa27186e96071fac7dd0d06a1873"},
+    {file = "coverage-5.5-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:970284a88b99673ccb2e4e334cfb38a10aab7cd44f7457564d11898a74b62d0a"},
+    {file = "coverage-5.5-cp38-cp38-win32.whl", hash = "sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6"},
+    {file = "coverage-5.5-cp38-cp38-win_amd64.whl", hash = "sha256:2e0d881ad471768bf6e6c2bf905d183543f10098e3b3640fc029509530091502"},
+    {file = "coverage-5.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d1f9ce122f83b2305592c11d64f181b87153fc2c2bbd3bb4a3dde8303cfb1a6b"},
+    {file = "coverage-5.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:13c4ee887eca0f4c5a247b75398d4114c37882658300e153113dafb1d76de529"},
+    {file = "coverage-5.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:52596d3d0e8bdf3af43db3e9ba8dcdaac724ba7b5ca3f6358529d56f7a166f8b"},
+    {file = "coverage-5.5-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:2cafbbb3af0733db200c9b5f798d18953b1a304d3f86a938367de1567f4b5bff"},
+    {file = "coverage-5.5-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:44d654437b8ddd9eee7d1eaee28b7219bec228520ff809af170488fd2fed3e2b"},
+    {file = "coverage-5.5-cp39-cp39-win32.whl", hash = "sha256:d314ed732c25d29775e84a960c3c60808b682c08d86602ec2c3008e1202e3bb6"},
+    {file = "coverage-5.5-cp39-cp39-win_amd64.whl", hash = "sha256:13034c4409db851670bc9acd836243aeee299949bd5673e11844befcb0149f03"},
+    {file = "coverage-5.5-pp36-none-any.whl", hash = "sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079"},
+    {file = "coverage-5.5-pp37-none-any.whl", hash = "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4"},
+    {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
 ]
 cryptography = [
     {file = "cryptography-3.4.6-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:57ad77d32917bc55299b16d3b996ffa42a1c73c6cfa829b14043c561288d2799"},
@@ -2057,8 +2091,8 @@ gitdb = [
     {file = "gitdb-4.0.5.tar.gz", hash = "sha256:c9e1f2d0db7ddb9a704c2a0217be31214e91a4fe1dea1efad19ae42ba0c285c9"},
 ]
 gitpython = [
-    {file = "GitPython-3.1.13-py3-none-any.whl", hash = "sha256:c5347c81d232d9b8e7f47b68a83e5dc92e7952127133c5f2df9133f2c75a1b29"},
-    {file = "GitPython-3.1.13.tar.gz", hash = "sha256:8621a7e777e276a5ec838b59280ba5272dd144a18169c36c903d8b38b99f750a"},
+    {file = "GitPython-3.1.14-py3-none-any.whl", hash = "sha256:3283ae2fba31c913d857e12e5ba5f9a7772bbc064ae2bb09efafa71b0dd4939b"},
+    {file = "GitPython-3.1.14.tar.gz", hash = "sha256:be27633e7509e58391f10207cd32b2a6cf5b908f92d9cd30da2e514e1137af61"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -2139,8 +2173,8 @@ jupyterlab-widgets = [
     {file = "jupyterlab_widgets-1.0.0.tar.gz", hash = "sha256:5c1a29a84d3069208cb506b10609175b249b6486d6b1cbae8fcde2a11584fb78"},
 ]
 keyring = [
-    {file = "keyring-22.0.1-py3-none-any.whl", hash = "sha256:9f44660a5d4931bdc14c08a1d01ef30b18a7a8147380710d8c9f9531e1f6c3c0"},
-    {file = "keyring-22.0.1.tar.gz", hash = "sha256:9acb3e1452edbb7544822b12fd25459078769e560fa51f418b6d00afaa6178df"},
+    {file = "keyring-22.3.0-py3-none-any.whl", hash = "sha256:2bc8363ebdd63886126a012057a85c8cb6e143877afa02619ac7dbc9f38a207b"},
+    {file = "keyring-22.3.0.tar.gz", hash = "sha256:16927a444b2c73f983520a48dec79ddab49fe76429ea05b8d528d778c8339522"},
 ]
 kiwisolver = [
     {file = "kiwisolver-1.3.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:fd34fbbfbc40628200730bc1febe30631347103fc8d3d4fa012c21ab9c11eca9"},
@@ -2346,24 +2380,22 @@ packaging = [
     {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
 ]
 pandas = [
-    {file = "pandas-1.2.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c76a108272a4de63189b8f64086bbaf8348841d7e610b52f50959fbbf401524f"},
-    {file = "pandas-1.2.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e61a089151f1ed78682aa77a3bcae0495cf8e585546c26924857d7e8a9960568"},
-    {file = "pandas-1.2.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:fc351cd2df318674669481eb978a7799f24fd14ef26987a1aa75105b0531d1a1"},
-    {file = "pandas-1.2.2-cp37-cp37m-win32.whl", hash = "sha256:05ca6bda50123158eb15e716789083ca4c3b874fd47688df1716daa72644ee1c"},
-    {file = "pandas-1.2.2-cp37-cp37m-win_amd64.whl", hash = "sha256:08b6bbe74ae2b3e4741a744d2bce35ce0868a6b4189d8b84be26bb334f73da4c"},
-    {file = "pandas-1.2.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:230de25bd9791748b2638c726a5f37d77a96a83854710110fadd068d1e2c2c9f"},
-    {file = "pandas-1.2.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:a50cf3110a1914442e7b7b9cef394ef6bed0d801b8a34d56f4c4e927bbbcc7d0"},
-    {file = "pandas-1.2.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:4d33537a375cfb2db4d388f9a929b6582a364137ea6c6b161b0166440d6ffe36"},
-    {file = "pandas-1.2.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8ac028cd9a6e1efe43f3dc36f708263838283535cc45430a98b9803f44f4c84b"},
-    {file = "pandas-1.2.2-cp38-cp38-win32.whl", hash = "sha256:c43d1beb098a1da15934262009a7120aac8dafa20d042b31dab48c28868eb5a4"},
-    {file = "pandas-1.2.2-cp38-cp38-win_amd64.whl", hash = "sha256:69a70d79a791fa1fd5f6e84b8b6dec2ec92369bde4ab2e18d43fc8a1825f51d1"},
-    {file = "pandas-1.2.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:cbad4155028b8ca66aa19a8b13f593ebbf51bfb6c3f2685fe64f04d695a81864"},
-    {file = "pandas-1.2.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:fbddbb20f30308ba2546193d64e18c23b69f59d48cdef73676cbed803495c8dc"},
-    {file = "pandas-1.2.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:214ae60b1f863844e97c87f758c29940ffad96c666257323a4bb2a33c58719c2"},
-    {file = "pandas-1.2.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:26b4919eb3039a686a86cd4f4a74224f8f66e3a419767da26909dcdd3b37c31e"},
-    {file = "pandas-1.2.2-cp39-cp39-win32.whl", hash = "sha256:e3c250faaf9979d0ec836d25e420428db37783fa5fed218da49c9fc06f80f51c"},
-    {file = "pandas-1.2.2-cp39-cp39-win_amd64.whl", hash = "sha256:e9bbcc7b5c432600797981706f5b54611990c6a86b2e424329c995eea5f9c42b"},
-    {file = "pandas-1.2.2.tar.gz", hash = "sha256:14ed84b463e9b84c8ff9308a79b04bf591ae3122a376ee0f62c68a1bd917a773"},
+    {file = "pandas-1.2.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:4d821b9b911fc1b7d428978d04ace33f0af32bb7549525c8a7b08444bce46b74"},
+    {file = "pandas-1.2.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:9f5829e64507ad10e2561b60baf285c470f3c4454b007c860e77849b88865ae7"},
+    {file = "pandas-1.2.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:97b1954533b2a74c7e20d1342c4f01311d3203b48f2ebf651891e6a6eaf01104"},
+    {file = "pandas-1.2.3-cp37-cp37m-win32.whl", hash = "sha256:5e3c8c60541396110586bcbe6eccdc335a38e7de8c217060edaf4722260b158f"},
+    {file = "pandas-1.2.3-cp37-cp37m-win_amd64.whl", hash = "sha256:8a051e957c5206f722e83f295f95a2cf053e890f9a1fba0065780a8c2d045f5d"},
+    {file = "pandas-1.2.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a93e34f10f67d81de706ce00bf8bb3798403cabce4ccb2de10c61b5ae8786ab5"},
+    {file = "pandas-1.2.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:46fc671c542a8392a4f4c13edc8527e3a10f6cb62912d856f82248feb747f06e"},
+    {file = "pandas-1.2.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:43e00770552595c2250d8d712ec8b6e08ca73089ac823122344f023efa4abea3"},
+    {file = "pandas-1.2.3-cp38-cp38-win32.whl", hash = "sha256:475b7772b6e18a93a43ea83517932deff33954a10d4fbae18d0c1aba4182310f"},
+    {file = "pandas-1.2.3-cp38-cp38-win_amd64.whl", hash = "sha256:72ffcea00ae8ffcdbdefff800284311e155fbb5ed6758f1a6110fc1f8f8f0c1c"},
+    {file = "pandas-1.2.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:621c044a1b5e535cf7dcb3ab39fca6f867095c3ef223a524f18f60c7fee028ea"},
+    {file = "pandas-1.2.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:0f27fd1adfa256388dc34895ca5437eaf254832223812afd817a6f73127f969c"},
+    {file = "pandas-1.2.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:dbb255975eb94143f2e6ec7dadda671d25147939047839cd6b8a4aff0379bb9b"},
+    {file = "pandas-1.2.3-cp39-cp39-win32.whl", hash = "sha256:d59842a5aa89ca03c2099312163ffdd06f56486050e641a45d926a072f04d994"},
+    {file = "pandas-1.2.3-cp39-cp39-win_amd64.whl", hash = "sha256:09761bf5f8c741d47d4b8b9073288de1be39bbfccc281d70b889ade12b2aad29"},
+    {file = "pandas-1.2.3.tar.gz", hash = "sha256:df6f10b85aef7a5bb25259ad651ad1cc1d6bb09000595cab47e718cbac250b1d"},
 ]
 pandocfilters = [
     {file = "pandocfilters-1.4.3.tar.gz", hash = "sha256:bc63fbb50534b4b1f8ebe1860889289e8af94a23bff7445259592df25a3906eb"},
@@ -2385,38 +2417,39 @@ pickleshare = [
     {file = "pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca"},
 ]
 pillow = [
-    {file = "Pillow-8.1.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:d355502dce85ade85a2511b40b4c61a128902f246504f7de29bbeec1ae27933a"},
-    {file = "Pillow-8.1.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:93a473b53cc6e0b3ce6bf51b1b95b7b1e7e6084be3a07e40f79b42e83503fbf2"},
-    {file = "Pillow-8.1.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:2353834b2c49b95e1313fb34edf18fca4d57446675d05298bb694bca4b194174"},
-    {file = "Pillow-8.1.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:1d208e670abfeb41b6143537a681299ef86e92d2a3dac299d3cd6830d5c7bded"},
-    {file = "Pillow-8.1.0-cp36-cp36m-win32.whl", hash = "sha256:dd9eef866c70d2cbbea1ae58134eaffda0d4bfea403025f4db6859724b18ab3d"},
-    {file = "Pillow-8.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:b09e10ec453de97f9a23a5aa5e30b334195e8d2ddd1ce76cc32e52ba63c8b31d"},
-    {file = "Pillow-8.1.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:b02a0b9f332086657852b1f7cb380f6a42403a6d9c42a4c34a561aa4530d5234"},
-    {file = "Pillow-8.1.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:ca20739e303254287138234485579b28cb0d524401f83d5129b5ff9d606cb0a8"},
-    {file = "Pillow-8.1.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:604815c55fd92e735f9738f65dabf4edc3e79f88541c221d292faec1904a4b17"},
-    {file = "Pillow-8.1.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cf6e33d92b1526190a1de904df21663c46a456758c0424e4f947ae9aa6088bf7"},
-    {file = "Pillow-8.1.0-cp37-cp37m-win32.whl", hash = "sha256:47c0d93ee9c8b181f353dbead6530b26980fe4f5485aa18be8f1fd3c3cbc685e"},
-    {file = "Pillow-8.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:96d4dc103d1a0fa6d47c6c55a47de5f5dafd5ef0114fa10c85a1fd8e0216284b"},
-    {file = "Pillow-8.1.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:7916cbc94f1c6b1301ac04510d0881b9e9feb20ae34094d3615a8a7c3db0dcc0"},
-    {file = "Pillow-8.1.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:3de6b2ee4f78c6b3d89d184ade5d8fa68af0848f9b6b6da2b9ab7943ec46971a"},
-    {file = "Pillow-8.1.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cdbbe7dff4a677fb555a54f9bc0450f2a21a93c5ba2b44e09e54fcb72d2bd13d"},
-    {file = "Pillow-8.1.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:f50e7a98b0453f39000619d845be8b06e611e56ee6e8186f7f60c3b1e2f0feae"},
-    {file = "Pillow-8.1.0-cp38-cp38-win32.whl", hash = "sha256:cb192176b477d49b0a327b2a5a4979552b7a58cd42037034316b8018ac3ebb59"},
-    {file = "Pillow-8.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:6c5275bd82711cd3dcd0af8ce0bb99113ae8911fc2952805f1d012de7d600a4c"},
-    {file = "Pillow-8.1.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:165c88bc9d8dba670110c689e3cc5c71dbe4bfb984ffa7cbebf1fac9554071d6"},
-    {file = "Pillow-8.1.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:5e2fe3bb2363b862671eba632537cd3a823847db4d98be95690b7e382f3d6378"},
-    {file = "Pillow-8.1.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7612520e5e1a371d77e1d1ca3a3ee6227eef00d0a9cddb4ef7ecb0b7396eddf7"},
-    {file = "Pillow-8.1.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d673c4990acd016229a5c1c4ee8a9e6d8f481b27ade5fc3d95938697fa443ce0"},
-    {file = "Pillow-8.1.0-cp39-cp39-win32.whl", hash = "sha256:dc577f4cfdda354db3ae37a572428a90ffdbe4e51eda7849bf442fb803f09c9b"},
-    {file = "Pillow-8.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:22d070ca2e60c99929ef274cfced04294d2368193e935c5d6febfd8b601bf865"},
-    {file = "Pillow-8.1.0-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:a3d3e086474ef12ef13d42e5f9b7bbf09d39cf6bd4940f982263d6954b13f6a9"},
-    {file = "Pillow-8.1.0-pp36-pypy36_pp73-manylinux2010_i686.whl", hash = "sha256:731ca5aabe9085160cf68b2dbef95fc1991015bc0a3a6ea46a371ab88f3d0913"},
-    {file = "Pillow-8.1.0-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:bba80df38cfc17f490ec651c73bb37cd896bc2400cfba27d078c2135223c1206"},
-    {file = "Pillow-8.1.0-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:c3d911614b008e8a576b8e5303e3db29224b455d3d66d1b2848ba6ca83f9ece9"},
-    {file = "Pillow-8.1.0-pp37-pypy37_pp73-manylinux2010_i686.whl", hash = "sha256:39725acf2d2e9c17356e6835dccebe7a697db55f25a09207e38b835d5e1bc032"},
-    {file = "Pillow-8.1.0-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:81c3fa9a75d9f1afafdb916d5995633f319db09bd773cb56b8e39f1e98d90820"},
-    {file = "Pillow-8.1.0-pp37-pypy37_pp73-win32.whl", hash = "sha256:b6f00ad5ebe846cc91763b1d0c6d30a8042e02b2316e27b05de04fa6ec831ec5"},
-    {file = "Pillow-8.1.0.tar.gz", hash = "sha256:887668e792b7edbfb1d3c9d8b5d8c859269a0f0eba4dda562adb95500f60dbba"},
+    {file = "Pillow-8.1.1-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:14415e9e28410232370615dbde0cf0a00e526f522f665460344a5b96973a3086"},
+    {file = "Pillow-8.1.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:924fc33cb4acaf6267b8ca3b8f1922620d57a28470d5e4f49672cea9a841eb08"},
+    {file = "Pillow-8.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:df534e64d4f3e84e8f1e1a37da3f541555d947c1c1c09b32178537f0f243f69d"},
+    {file = "Pillow-8.1.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:4fe74636ee71c57a7f65d7b21a9f127d842b4fb75511e5d256ace258826eb352"},
+    {file = "Pillow-8.1.1-cp36-cp36m-win32.whl", hash = "sha256:3e759bcc03d6f39bc751e56d86bc87252b9a21c689a27c5ed753717a87d53a5b"},
+    {file = "Pillow-8.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:292f2aa1ae5c5c1451cb4b558addb88c257411d3fd71c6cf45562911baffc979"},
+    {file = "Pillow-8.1.1-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:8211cac9bf10461f9e33fe9a3af6c5131f3fdd0d10672afc2abb2c70cf95c5ca"},
+    {file = "Pillow-8.1.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:d30f30c044bdc0ab8f3924e1eeaac87e0ff8a27e87369c5cac4064b6ec78fd83"},
+    {file = "Pillow-8.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:7094bbdecb95ebe53166e4c12cf5e28310c2b550b08c07c5dc15433898e2238e"},
+    {file = "Pillow-8.1.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:1022f8f6dc3c5b0dcf928f1c49ba2ac73051f576af100d57776e2b65c1f76a8d"},
+    {file = "Pillow-8.1.1-cp37-cp37m-win32.whl", hash = "sha256:a7d690b2c5f7e4a932374615fedceb1e305d2dd5363c1de15961725fe10e7d16"},
+    {file = "Pillow-8.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:436b0a2dd9fe3f7aa6a444af6bdf53c1eb8f5ced9ea3ef104daa83f0ea18e7bc"},
+    {file = "Pillow-8.1.1-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:c448d2b335e21951416a30cd48d35588d122a912d5fe9e41900afacecc7d21a1"},
+    {file = "Pillow-8.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:bb18422ad00c1fecc731d06592e99c3be2c634da19e26942ba2f13d805005cf2"},
+    {file = "Pillow-8.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:3ec87bd1248b23a2e4e19e774367fbe30fddc73913edc5f9b37470624f55dc1f"},
+    {file = "Pillow-8.1.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:99ce3333b40b7a4435e0a18baad468d44ab118a4b1da0af0a888893d03253f1d"},
+    {file = "Pillow-8.1.1-cp38-cp38-win32.whl", hash = "sha256:2f0d7034d5faae9a8d1019d152ede924f653df2ce77d3bba4ce62cd21b5f94ae"},
+    {file = "Pillow-8.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:07872f1d8421db5a3fe770f7480835e5e90fddb58f36c216d4a2ac0d594de474"},
+    {file = "Pillow-8.1.1-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:69da5b1d7102a61ce9b45deb2920a2012d52fd8f4201495ea9411d0071b0ec22"},
+    {file = "Pillow-8.1.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2a40d7d4b17db87f5b9a1efc0aff56000e1d0d5ece415090c102aafa0ccbe858"},
+    {file = "Pillow-8.1.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:01bb0a34f1a6689b138c0089d670ae2e8f886d2666a9b2f2019031abdea673c4"},
+    {file = "Pillow-8.1.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:43b3c859912e8bf754b3c5142df624794b18eb7ae07cfeddc917e1a9406a3ef2"},
+    {file = "Pillow-8.1.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:3b13d89d97b551e02549d1f0edf22bed6acfd6fd2e888cd1e9a953bf215f0e81"},
+    {file = "Pillow-8.1.1-cp39-cp39-win32.whl", hash = "sha256:c143c409e7bc1db784471fe9d0bf95f37c4458e879ad84cfae640cb74ee11a26"},
+    {file = "Pillow-8.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:1c5e3c36f02c815766ae9dd91899b1c5b4652f2a37b7a51609f3bd467c0f11fb"},
+    {file = "Pillow-8.1.1-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:8cf77e458bd996dc85455f10fe443c0c946f5b13253773439bcbec08aa1aebc2"},
+    {file = "Pillow-8.1.1-pp36-pypy36_pp73-manylinux2010_i686.whl", hash = "sha256:c10af40ee2f1a99e1ae755ab1f773916e8bca3364029a042cd9161c400416bd8"},
+    {file = "Pillow-8.1.1-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:ff83dfeb04c98bb3e7948f876c17513a34e9a19fd92e292288649164924c1b39"},
+    {file = "Pillow-8.1.1-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:b9af590adc1e46898a1276527f3cfe2da8048ae43fbbf9b1bf9395f6c99d9b47"},
+    {file = "Pillow-8.1.1-pp37-pypy37_pp73-manylinux2010_i686.whl", hash = "sha256:172acfaf00434a28dddfe592d83f2980e22e63c769ff4a448ddf7b7a38ffd165"},
+    {file = "Pillow-8.1.1-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:33fdbd4f5608c852d97264f9d2e3b54e9e9959083d008145175b86100b275e5b"},
+    {file = "Pillow-8.1.1-pp37-pypy37_pp73-win32.whl", hash = "sha256:59445af66b59cc39530b4f810776928d75e95f41e945f0c32a3de4aceb93c15d"},
+    {file = "Pillow-8.1.1.tar.gz", hash = "sha256:f6fc18f9c9c7959bf58e6faf801d14fafb6d4717faaf6f79a68c8bb2a13dcf20"},
 ]
 pkginfo = [
     {file = "pkginfo-1.7.0-py2.py3-none-any.whl", hash = "sha256:9fdbea6495622e022cc72c2e5e1b735218e4ffb2a2a69cde2694a6c1f16afb75"},
@@ -2734,14 +2767,14 @@ send2trash = [
     {file = "Send2Trash-1.5.0.tar.gz", hash = "sha256:60001cc07d707fe247c94f74ca6ac0d3255aabcb930529690897ca2a39db28b2"},
 ]
 setuptools-scm = [
-    {file = "setuptools_scm-5.0.1-py2.7.egg", hash = "sha256:db4ab2e0c2644ba71b1e5212b14ff65dbf0af465796d314a75e0cf6128f605f7"},
-    {file = "setuptools_scm-5.0.1-py2.py3-none-any.whl", hash = "sha256:62fa535edb31ece9fa65dc9dcb3056145b8020c8c26c0ef1018aef33db95c40d"},
-    {file = "setuptools_scm-5.0.1-py3.5.egg", hash = "sha256:1fc4e25df445351d172bb4788f4d07f9e9ce0e8b7dee6b19584e46110172ca13"},
-    {file = "setuptools_scm-5.0.1-py3.6.egg", hash = "sha256:e878036c2527dfd05818727846338be86b2be6955741b85fab2625f63d001021"},
-    {file = "setuptools_scm-5.0.1-py3.7.egg", hash = "sha256:eb19b46816fc106a4c2d4180022687eab40f9773cf61390b845afb093d1f4ecd"},
-    {file = "setuptools_scm-5.0.1-py3.8.egg", hash = "sha256:48b31488d089270500f120efea723968c01abd85fd4876043a3b7c7ef7d0b761"},
-    {file = "setuptools_scm-5.0.1-py3.9.egg", hash = "sha256:b928021c4381f96d577847d540d6e03065f8f8851c768a0c9bc552d463bae0d4"},
-    {file = "setuptools_scm-5.0.1.tar.gz", hash = "sha256:c85b6b46d0edd40d2301038cdea96bb6adc14d62ef943e75afb08b3e7bcf142a"},
+    {file = "setuptools_scm-5.0.2-py2.7.egg", hash = "sha256:35acc9a3be4fbd4f6f3480eecb3c637dfb5ca1812fe86baf5e6759a0133837cf"},
+    {file = "setuptools_scm-5.0.2-py2.py3-none-any.whl", hash = "sha256:bd5c4e37f74c103e117549f89aeb3c244488c4a6422df786d1a7d03257f16b34"},
+    {file = "setuptools_scm-5.0.2-py3.5.egg", hash = "sha256:0d4fa3743c7a453f31dae9b44fcc0c869125a323c166a6b39e20122f488addb2"},
+    {file = "setuptools_scm-5.0.2-py3.6.egg", hash = "sha256:ce5497a8ff55e81cf88cb402a87dedc7663d2671d5f1303d978ba1afb33c4fb6"},
+    {file = "setuptools_scm-5.0.2-py3.7.egg", hash = "sha256:90be2ecff71d92352f59c6371abe017c0859bc617a545ba6aaf4d96951ba7947"},
+    {file = "setuptools_scm-5.0.2-py3.8.egg", hash = "sha256:2e8706b90910d66668b3f34aea9cceab3c08ba83fedd78de65ff323edc8a1414"},
+    {file = "setuptools_scm-5.0.2-py3.9.egg", hash = "sha256:f23060f0f5b23f26b76e43fb0ef51e5294e4b575f69edab5cfe442635680f2ec"},
+    {file = "setuptools_scm-5.0.2.tar.gz", hash = "sha256:83a0cedd3449e3946307811a4c7b9d89c4b5fd464a2fb5eeccd0a5bb158ae5c8"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
@@ -2866,6 +2899,10 @@ tomlkit = [
     {file = "tomlkit-0.7.0-py2.py3-none-any.whl", hash = "sha256:6babbd33b17d5c9691896b0e68159215a9387ebfa938aa3ac42f4a4beeb2b831"},
     {file = "tomlkit-0.7.0.tar.gz", hash = "sha256:ac57f29693fab3e309ea789252fcce3061e19110085aa31af5446ca749325618"},
 ]
+toolz = [
+    {file = "toolz-0.11.1-py3-none-any.whl", hash = "sha256:1bc473acbf1a1db4e72a1ce587be347450e8f08324908b8a266b486f408f04d5"},
+    {file = "toolz-0.11.1.tar.gz", hash = "sha256:c7a47921f07822fe534fb1c01c9931ab335a4390c782bd28c6bcc7c2f71f3fbf"},
+]
 tornado = [
     {file = "tornado-6.1-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:d371e811d6b156d82aa5f9a4e08b58debf97c302a35714f6f45e35139c332e32"},
     {file = "tornado-6.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:0d321a39c36e5f2c4ff12b4ed58d41390460f798422c4504e09eb5678e09998c"},
@@ -2910,8 +2947,8 @@ tornado = [
     {file = "tornado-6.1.tar.gz", hash = "sha256:33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791"},
 ]
 tqdm = [
-    {file = "tqdm-4.57.0-py2.py3-none-any.whl", hash = "sha256:70657337ec104eb4f3fb229285358f23f045433f6aea26846cdd55f0fd68945c"},
-    {file = "tqdm-4.57.0.tar.gz", hash = "sha256:65185676e9fdf20d154cffd1c5de8e39ef9696ff7e59fe0156b1b08e468736af"},
+    {file = "tqdm-4.59.0-py2.py3-none-any.whl", hash = "sha256:9fdf349068d047d4cfbe24862c425883af1db29bcddf4b0eeb2524f6fbdb23c7"},
+    {file = "tqdm-4.59.0.tar.gz", hash = "sha256:d666ae29164da3e517fcf125e41d4fe96e5bb375cd87ff9763f6b38b5592fe33"},
 ]
 traitlets = [
     {file = "traitlets-5.0.5-py3-none-any.whl", hash = "sha256:69ff3f9d5351f31a7ad80443c2674b7099df13cc41fc5fa6e2f6d3b0330b0426"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ en-core-web-md = {url = "https://github.com/explosion/spacy-models/releases/down
 pytest = "^6.2.2"
 wordcloud = "^1.8.1"
 jupyter = "^1.0.0"
+altair = "^4.1.0"
 
 [tool.poetry.dev-dependencies]
 pytest-cov = "^2.11.1"

--- a/tests/data/menu_subset.csv
+++ b/tests/data/menu_subset.csv
@@ -1,0 +1,261 @@
+Category,Item,Serving Size,Calories,Cholesterol,Sodium,Carbohydrates
+Breakfast,Egg McMuffin,4.8 oz (136 g),300,260,750,31
+Breakfast,Egg White Delight,4.8 oz (135 g),250,25,770,30
+Breakfast,Sausage McMuffin,3.9 oz (111 g),370,45,780,29
+Breakfast,Sausage McMuffin with Egg,5.7 oz (161 g),450,285,860,30
+Breakfast,Sausage McMuffin with Egg Whites,5.7 oz (161 g),400,50,880,30
+Breakfast,Steak & Egg McMuffin,6.5 oz (185 g),430,300,960,31
+Breakfast,"Bacon, Egg & Cheese Biscuit (Regular Biscuit)",5.3 oz (150 g),460,250,1300,38
+Breakfast,"Bacon, Egg & Cheese Biscuit (Large Biscuit)",5.8 oz (164 g),520,250,1410,43
+Breakfast,"Bacon, Egg & Cheese Biscuit with Egg Whites (Regular Biscuit)",5.4 oz (153 g),410,35,1300,36
+Breakfast,"Bacon, Egg & Cheese Biscuit with Egg Whites (Large Biscuit)",5.9 oz (167 g),470,35,1420,42
+Breakfast,Sausage Biscuit (Regular Biscuit),4.1 oz (117 g),430,30,1080,34
+Breakfast,Sausage Biscuit (Large Biscuit),4.6 oz (131 g),480,30,1190,39
+Breakfast,Sausage Biscuit with Egg (Regular Biscuit),5.7 oz (163 g),510,250,1170,36
+Breakfast,Sausage Biscuit with Egg (Large Biscuit),6.2 oz (177 g),570,250,1280,42
+Breakfast,Sausage Biscuit with Egg Whites (Regular Biscuit),5.9 oz (167 g),460,35,1180,34
+Breakfast,Sausage Biscuit with Egg Whites (Large Biscuit),6.4 oz (181 g),520,35,1290,40
+Breakfast,Southern Style Chicken Biscuit (Regular Biscuit),5 oz (143 g),410,30,1180,41
+Breakfast,Southern Style Chicken Biscuit (Large Biscuit),5.5 oz (157 g),470,30,1290,46
+Breakfast,Steak & Egg Biscuit (Regular Biscuit),7.1 oz (201 g),540,280,1470,38
+Breakfast,"Bacon, Egg & Cheese McGriddles",6.1 oz (174 g),460,250,1250,48
+Breakfast,"Bacon, Egg & Cheese McGriddles with Egg Whites",6.3 oz (178 g),400,35,1250,47
+Breakfast,Sausage McGriddles,5 oz (141 g),420,35,1030,44
+Breakfast,"Sausage, Egg & Cheese McGriddles",7.1 oz (201 g),550,265,1320,48
+Breakfast,"Sausage, Egg & Cheese McGriddles with Egg Whites",7.2 oz (205 g),500,50,1320,46
+Breakfast,"Bacon, Egg & Cheese Bagel",6.9 oz (197 g),620,275,1480,57
+Breakfast,"Bacon, Egg & Cheese Bagel with Egg Whites",7.1 oz (201 g),570,60,1480,55
+Breakfast,"Steak, Egg & Cheese Bagel",8.5 oz (241 g),670,295,1510,56
+Breakfast,Big Breakfast (Regular Biscuit),9.5 oz (269 g),740,555,1560,51
+Breakfast,Big Breakfast (Large Biscuit),10 oz (283 g),800,555,1680,56
+Breakfast,Big Breakfast with Egg Whites (Regular Biscuit),9.6 oz (272 g),640,35,1590,50
+Breakfast,Big Breakfast with Egg Whites (Large Biscuit),10.1 oz (286 g),690,35,1700,55
+Breakfast,Big Breakfast with Hotcakes (Regular Biscuit),14.8 oz (420 g),1090,575,2150,111
+Breakfast,Big Breakfast with Hotcakes (Large Biscuit),15.3 oz (434 g),1150,575,2260,116
+Breakfast,Big Breakfast with Hotcakes and Egg Whites (Regular Biscuit),14.9 oz (423 g),990,55,2170,110
+Breakfast,Big Breakfast with Hotcakes and Egg Whites (Large Biscuit),15.4 oz (437 g),1050,55,2290,115
+Breakfast,Hotcakes,5.3 oz (151 g),350,20,590,60
+Breakfast,Hotcakes and Sausage,6.8 oz (192 g),520,50,930,61
+Breakfast,Sausage Burrito,3.9 oz (111 g),300,115,790,26
+Breakfast,Hash Brown,2 oz (56 g),150,0,310,15
+Breakfast,Cinnamon Melts,4 oz (114 g),460,15,370,66
+Breakfast,Fruit & Maple Oatmeal,9.6 oz (251 g),290,5,160,58
+Breakfast,Fruit & Maple Oatmeal without Brown Sugar,9.6 oz (251 g),260,5,115,49
+Beef & Pork,Big Mac,7.4 oz (211 g),530,85,960,47
+Beef & Pork,Quarter Pounder with Cheese,7.1 oz (202 g),520,95,1100,41
+Beef & Pork,Quarter Pounder with Bacon & Cheese,8 oz (227 g),600,105,1440,48
+Beef & Pork,Quarter Pounder with Bacon Habanero Ranch,8.3 oz (235 g),610,105,1180,46
+Beef & Pork,Quarter Pounder Deluxe,8.6 oz (244 g),540,85,960,45
+Beef & Pork,Double Quarter Pounder with Cheese,10 oz (283 g),750,160,1280,42
+Beef & Pork,Hamburger,3.5 oz (98 g),240,30,480,32
+Beef & Pork,Cheeseburger,4 oz (113 g),290,45,680,33
+Beef & Pork,Double Cheeseburger,5.7 oz (161 g),430,90,1040,35
+Beef & Pork,Bacon Clubhouse Burger,9.5 oz (270 g),720,115,1470,51
+Beef & Pork,McDouble,5.2 oz (147 g),380,75,840,34
+Beef & Pork,Bacon McDouble,5.7 oz (161 g),440,90,1110,35
+Beef & Pork,Daily Double,6.7 oz (190 g),430,80,760,34
+Beef & Pork,Jalapeño Double,5.6 oz (159 g),430,80,1030,35
+Beef & Pork,McRib,7.3 oz (208 g),500,70,980,44
+Chicken & Fish,Premium Crispy Chicken Classic Sandwich,7.5 oz (213 g),510,45,990,55
+Chicken & Fish,Premium Grilled Chicken Classic Sandwich,7 oz (200 g),350,65,820,42
+Chicken & Fish,Premium Crispy Chicken Club Sandwich,8.8 oz (249 g),670,85,1410,58
+Chicken & Fish,Premium Grilled Chicken Club Sandwich,8.3 oz (235 g),510,105,1250,44
+Chicken & Fish,Premium Crispy Chicken Ranch BLT Sandwich,8.1 oz (230 g),610,70,1400,57
+Chicken & Fish,Premium Grilled Chicken Ranch BLT Sandwich,7.6 oz (217 g),450,90,1230,43
+Chicken & Fish,Bacon Clubhouse Crispy Chicken Sandwich,10 oz (284 g),750,90,1720,65
+Chicken & Fish,Bacon Clubhouse Grilled Chicken Sandwich,9.5 oz (270 g),590,110,1560,51
+Chicken & Fish,Southern Style Crispy Chicken Sandwich,5.6 oz (160 g),430,45,910,43
+Chicken & Fish,McChicken,5.1 oz (143 g),360,35,800,40
+Chicken & Fish,Bacon Cheddar McChicken,6 oz (171 g),480,65,1260,43
+Chicken & Fish,Bacon Buffalo Ranch McChicken,5.7 oz (161 g),430,50,1260,41
+Chicken & Fish,Buffalo Ranch McChicken,5.2 oz (148 g),360,35,990,40
+Chicken & Fish,Premium McWrap Chicken & Bacon (Crispy Chicken),11.1 oz (316 g),630,80,1540,56
+Chicken & Fish,Premium McWrap Chicken & Bacon (Grilled Chicken),10.7 oz (302 g),480,95,1370,42
+Chicken & Fish,Premium McWrap Chicken & Ranch (Crispy Chicken),10.9 oz (310 g),610,65,1340,56
+Chicken & Fish,Premium McWrap Chicken & Ranch (Grilled Chicken),10.5 oz (297 g),450,80,1170,42
+Chicken & Fish,Premium McWrap Southwest Chicken (Crispy Chicken),11.1 oz (314 g),670,60,1480,68
+Chicken & Fish,Premium McWrap Southwest Chicken (Grilled Chicken),11.2 oz (318 g),520,80,1320,55
+Chicken & Fish,Premium McWrap Chicken Sweet Chili (Crispy Chicken),10.7 oz (304 g),540,50,1260,61
+Chicken & Fish,Premium McWrap Chicken Sweet Chili (Grilled Chicken),10.3 oz (291 g),380,65,1090,47
+Chicken & Fish,Chicken McNuggets (4 piece),2.3 oz (65 g),190,25,360,12
+Chicken & Fish,Chicken McNuggets (6 piece),3.4 oz (97 g),280,40,540,18
+Chicken & Fish,Chicken McNuggets (10 piece),5.7 oz (162 g),470,65,900,30
+Chicken & Fish,Chicken McNuggets (20 piece),11.4 oz (323 g),940,135,1800,59
+Chicken & Fish,Chicken McNuggets (40 piece),22.8 oz (646 g),1880,265,3600,118
+Chicken & Fish,Filet-O-Fish,5 oz (142 g),390,40,590,39
+Salads,Premium Bacon Ranch Salad (without Chicken),7.9 oz (223 g),140,25,300,10
+Salads,Premium Bacon Ranch Salad with Crispy Chicken,9 oz (255 g),380,70,860,22
+Salads,Premium Bacon Ranch Salad with Grilled Chicken,8.5 oz (241 g),220,85,690,8
+Salads,Premium Southwest Salad (without Chicken),8.1 oz (230 g),140,10,150,20
+Salads,Premium Southwest Salad with Crispy Chicken,12.3 oz (348 g),450,50,850,42
+Salads,Premium Southwest Salad with Grilled Chicken,11.8 oz (335 g),290,70,680,28
+Snacks & Sides,Chipotle BBQ Snack Wrap (Crispy Chicken),4.6 oz (130 g),340,30,780,37
+Snacks & Sides,Chipotle BBQ Snack Wrap (Grilled Chicken),4.3 oz (123 g),260,40,700,30
+Snacks & Sides,Honey Mustard Snack Wrap (Crispy Chicken),4.3 oz (123 g),330,35,730,34
+Snacks & Sides,Honey Mustard Snack Wrap (Grilled Chicken),4.1 oz (116 g),250,45,650,27
+Snacks & Sides,Ranch Snack Wrap (Crispy Chicken),4.5 oz (128 g),360,40,810,32
+Snacks & Sides,Ranch Snack Wrap (Grilled Chicken),4.3 oz (121 g),280,45,720,25
+Snacks & Sides,Small French Fries,2.6 oz (75 g),230,0,130,30
+Snacks & Sides,Medium French Fries,3.9 oz (111 g),340,0,190,44
+Snacks & Sides,Large French Fries,5.9 oz (168 g),510,0,290,67
+Snacks & Sides,Kids French Fries,1.3 oz (38 g),110,0,65,15
+Snacks & Sides,Side Salad,3.1 oz (87 g),20,0,10,4
+Snacks & Sides,Apple Slices,1.2 oz (34 g),15,0,0,4
+Snacks & Sides,Fruit 'n Yogurt Parfait,5.2 oz (149 g),150,5,70,30
+Desserts,Baked Apple Pie,2.7 oz (77 g),250,0,170,32
+Desserts,Chocolate Chip Cookie,1 cookie (33 g),160,10,90,21
+Desserts,Oatmeal Raisin Cookie,1 cookie (33 g),150,10,135,22
+Desserts,Kids Ice Cream Cone,1 oz (29 g),45,5,20,7
+Desserts,Hot Fudge Sundae,6.3 oz (179 g),330,25,170,53
+Desserts,Hot Caramel Sundae,6.4 oz (182 g),340,30,150,60
+Desserts,Strawberry Sundae,6.3 oz (178 g),280,25,85,49
+Beverages,Coca-Cola Classic (Small),16 fl oz cup,140,0,0,39
+Beverages,Coca-Cola Classic (Medium),21 fl oz cup,200,0,5,55
+Beverages,Coca-Cola Classic (Large),30 fl oz cup,280,0,5,76
+Beverages,Coca-Cola Classic (Child),12 fl oz cup,100,0,0,28
+Beverages,Diet Coke (Small),16 fl oz cup,0,0,10,0
+Beverages,Diet Coke (Medium),21 fl oz cup,0,0,20,0
+Beverages,Diet Coke (Large),30 fl oz cup,0,0,35,0
+Beverages,Diet Coke (Child),12 fl oz cup,0,0,15,0
+Beverages,Dr Pepper (Small),16 fl oz cup,140,0,45,37
+Beverages,Dr Pepper (Medium),21 fl oz cup,190,0,65,53
+Beverages,Dr Pepper (Large),30 fl oz cup,270,0,90,72
+Beverages,Dr Pepper (Child),12 fl oz cup,100,0,30,27
+Beverages,Diet Dr Pepper (Small),16 fl oz cup,0,0,70,0
+Beverages,Diet Dr Pepper (Medium),21 fl oz cup,0,0,100,0
+Beverages,Diet Dr Pepper (Large),30 fl oz cup,0,0,140,0
+Beverages,Diet Dr Pepper (Child),12 fl oz cup,0,0,50,0
+Beverages,Sprite (Small),16 fl oz cup,140,0,30,37
+Beverages,Sprite (Medium),21 fl oz cup,200,0,45,54
+Beverages,Sprite (Large),30 fl oz cup,280,0,60,74
+Beverages,Sprite (Child),12 fl oz cup,100,0,25,27
+Beverages,1% Low Fat Milk Jug,1 carton (236 ml),100,10,125,12
+Beverages,Fat Free Chocolate Milk Jug,1 carton (236 ml),130,5,135,23
+Beverages,Minute Maid 100% Apple Juice Box,6 fl oz (177 ml),80,0,15,21
+Beverages,Minute Maid Orange Juice (Small),12 fl oz cup,150,0,0,34
+Beverages,Minute Maid Orange Juice (Medium),16 fl oz cup,190,0,0,44
+Beverages,Minute Maid Orange Juice (Large),22 fl oz cup,280,0,5,65
+Beverages,Dasani Water Bottle,16.9 fl oz,0,0,0,0
+Coffee & Tea,Iced Tea (Small),16 fl oz cup,0,0,10,0
+Coffee & Tea,Iced Tea (Medium),21 fl oz cup,0,0,10,0
+Coffee & Tea,Iced Tea (Large),30 fl oz cup,0,0,15,0
+Coffee & Tea,Iced Tea (Child),12 fl oz cup,0,0,5,0
+Coffee & Tea,Sweet Tea (Small),16 fl oz cup,150,0,10,36
+Coffee & Tea,Sweet Tea (Medium),21 fl oz cup,180,0,10,45
+Coffee & Tea,Sweet Tea (Large),30 fl oz cup,220,0,10,54
+Coffee & Tea,Sweet Tea (Child),12 fl oz cup,110,0,5,27
+Coffee & Tea,Coffee (Small),12 fl oz cup,0,0,0,0
+Coffee & Tea,Coffee (Medium),16 fl oz cup,0,0,0,0
+Coffee & Tea,Coffee (Large),16 fl oz cup,0,0,0,0
+Coffee & Tea,Latte (Small),12 fl oz cup,170,25,115,15
+Coffee & Tea,Latte (Medium),16 fl oz cup,210,30,140,18
+Coffee & Tea,Latte (Large),20 fl oz cup,280,40,180,24
+Coffee & Tea,Caramel Latte (Small),12 fl oz cup,270,25,115,40
+Coffee & Tea,Caramel Latte (Medium),16 fl oz cup,340,30,140,50
+Coffee & Tea,Caramel Latte (Large),20 fl oz cup,430,40,180,62
+Coffee & Tea,Hazelnut Latte (Small),12 fl oz cup,270,25,115,40
+Coffee & Tea,Hazelnut Latte (Medium),16 fl oz cup,330,30,140,50
+Coffee & Tea,Hazelnut Latte (Large),20 fl oz cup,430,40,180,62
+Coffee & Tea,French Vanilla Latte (Small),12 fl oz cup,260,25,115,38
+Coffee & Tea,French Vanilla Latte (Medium),16 fl oz cup,330,30,140,48
+Coffee & Tea,French Vanilla Latte (Large),20 fl oz cup,420,40,190,60
+Coffee & Tea,Latte with Sugar Free French Vanilla Syrup (Small),12 fl oz cup,210,25,150,24
+Coffee & Tea,Latte with Sugar Free French Vanilla Syrup (Medium),16 fl oz cup,260,30,190,29
+Coffee & Tea,Latte with Sugar Free French Vanilla Syrup (Large),20 fl oz cup,330,40,240,37
+Coffee & Tea,Nonfat Latte (Small),12 fl oz cup,100,5,110,15
+Coffee & Tea,Nonfat Latte (Medium),16 fl oz cup,130,5,135,19
+Coffee & Tea,Nonfat Latte (Large),20 fl oz cup,170,10,180,25
+Coffee & Tea,Nonfat Caramel Latte (Small),12 fl oz cup,200,5,110,41
+Coffee & Tea,Nonfat Caramel Latte (Medium),16 fl oz cup,250,5,135,51
+Coffee & Tea,Nonfat Caramel Latte (Large),20 fl oz cup,310,10,180,63
+Coffee & Tea,Nonfat Hazelnut Latte (Small),12 fl oz cup,200,5,110,40
+Coffee & Tea,Nonfat Hazelnut Latte (Medium),16 fl oz cup,250,5,135,51
+Coffee & Tea,Nonfat Hazelnut Latte (Large),20 fl oz cup,310,10,180,63
+Coffee & Tea,Nonfat French Vanilla Latte (Small),12 fl oz cup,190,5,115,39
+Coffee & Tea,Nonfat French Vanilla Latte (Medium),16 fl oz cup,240,5,140,49
+Coffee & Tea,Nonfat French Vanilla Latte (Large),20 fl oz cup,300,10,180,60
+Coffee & Tea,Nonfat Latte with Sugar Free French Vanilla Syrup (Small),12 fl oz cup,140,5,150,24
+Coffee & Tea,Nonfat Latte with Sugar Free French Vanilla Syrup (Medium),16 fl oz cup,170,5,180,30
+Coffee & Tea,Nonfat Latte with Sugar Free French Vanilla Syrup (Large),20 fl oz cup,220,10,240,38
+Coffee & Tea,Mocha (Small),12 fl oz cup,340,35,150,49
+Coffee & Tea,Mocha (Medium),16 fl oz cup,410,40,190,60
+Coffee & Tea,Mocha (Large),20 fl oz cup,500,50,240,72
+Coffee & Tea,Mocha with Nonfat Milk (Small),12 fl oz cup,270,15,150,49
+Coffee & Tea,Mocha with Nonfat Milk (Medium),16 fl oz cup,330,15,190,60
+Coffee & Tea,Mocha with Nonfat Milk (Large),20 fl oz cup,390,20,240,73
+Coffee & Tea,Caramel Mocha (Small),12 fl oz cup,320,35,170,45
+Coffee & Tea,Caramel Mocha (Medium),16 fl oz cup,390,40,220,55
+Coffee & Tea,Caramel Mocha (Large),20 fl oz cup,480,50,270,66
+Coffee & Tea,Nonfat Caramel Mocha (Small),12 fl oz cup,250,15,170,45
+Coffee & Tea,Nonfat Caramel Mocha (Medium),16 fl oz cup,310,15,210,56
+Coffee & Tea,Nonfat Caramel Mocha (Large),20 fl oz cup,370,20,270,67
+Coffee & Tea,Hot Chocolate (Small),12 fl oz cup,360,40,180,50
+Coffee & Tea,Hot Chocolate (Medium),16 fl oz cup,440,50,220,61
+Coffee & Tea,Hot Chocolate (Large),20 fl oz cup,540,60,280,73
+Coffee & Tea,Hot Chocolate with Nonfat Milk (Small),12 fl oz cup,280,15,180,50
+Coffee & Tea,Hot Chocolate with Nonfat Milk (Medium),16 fl oz cup,340,15,220,61
+Coffee & Tea,Hot Chocolate with Nonfat Milk (Large),20 fl oz cup,400,20,280,74
+Coffee & Tea,Regular Iced Coffee (Small),16 fl oz cup,140,15,35,23
+Coffee & Tea,Regular Iced Coffee (Medium),22 fl oz cup,190,25,50,31
+Coffee & Tea,Regular Iced Coffee (Large),32 fl oz cup,270,35,75,47
+Coffee & Tea,Caramel Iced Coffee (Small),16 fl oz cup,130,15,35,22
+Coffee & Tea,Caramel Iced Coffee (Medium),22 fl oz cup,180,25,50,29
+Coffee & Tea,Caramel Iced Coffee (Large),32 fl oz cup,260,35,65,43
+Coffee & Tea,Hazelnut Iced Coffee (Small),16 fl oz cup,130,15,35,21
+Coffee & Tea,Hazelnut Iced Coffee (Medium),22 fl oz cup,180,25,50,29
+Coffee & Tea,Hazelnut Iced Coffee (Large),32 fl oz cup,250,35,75,43
+Coffee & Tea,French Vanilla Iced Coffee (Small),16 fl oz cup,120,15,40,20
+Coffee & Tea,French Vanilla Iced Coffee (Medium),22 fl oz cup,170,25,55,27
+Coffee & Tea,French Vanilla Iced Coffee (Large),32 fl oz cup,240,35,80,41
+Coffee & Tea,Iced Coffee with Sugar Free French Vanilla Syrup (Small),16 fl oz cup,80,15,65,9
+Coffee & Tea,Iced Coffee with Sugar Free French Vanilla Syrup (Medium),22 fl oz cup,120,25,90,12
+Coffee & Tea,Iced Coffee with Sugar Free French Vanilla Syrup (Large),32 fl oz cup,160,35,135,18
+Coffee & Tea,Iced Mocha (Small),12 fl oz cup,290,35,125,41
+Coffee & Tea,Iced Mocha (Medium),16 fl oz cup,350,40,150,50
+Coffee & Tea,Iced Mocha (Large),22 fl oz cup,480,50,220,70
+Coffee & Tea,Iced Mocha with Nonfat Milk (Small),12 fl oz cup,240,20,125,41
+Coffee & Tea,Iced Mocha with Nonfat Milk (Medium),16 fl oz cup,290,20,150,50
+Coffee & Tea,Iced Mocha with Nonfat Milk (Large),22 fl oz cup,390,25,220,71
+Coffee & Tea,Iced Caramel Mocha (Small),12 fl oz cup,280,35,140,38
+Coffee & Tea,Iced Caramel Mocha (Medium),16 fl oz cup,340,40,170,46
+Coffee & Tea,Iced Caramel Mocha (Large),22 fl oz cup,460,50,250,65
+Coffee & Tea,Iced Nonfat Caramel Mocha (Small),12 fl oz cup,230,20,140,38
+Coffee & Tea,Iced Nonfat Caramel Mocha (Medium),16 fl oz cup,270,20,170,47
+Coffee & Tea,Iced Nonfat Caramel Mocha (Large),22 fl oz cup,370,25,250,65
+Coffee & Tea,Frappé Mocha (Small),12 fl oz cup,450,65,125,65
+Coffee & Tea,Frappé Mocha (Medium),16 fl oz cup,550,75,160,80
+Coffee & Tea,Frappé Mocha (Large),22 fl oz cup,670,90,190,98
+Coffee & Tea,Frappé Caramel (Small),12 fl oz cup,450,65,125,64
+Coffee & Tea,Frappé Caramel (Medium),16 fl oz cup,550,80,160,79
+Coffee & Tea,Frappé Caramel (Large),22 fl oz cup,670,95,190,96
+Coffee & Tea,Frappé Chocolate Chip (Small),12 fl oz cup,530,65,135,76
+Coffee & Tea,Frappé Chocolate Chip (Medium),16 fl oz cup,630,80,160,91
+Coffee & Tea,Frappé Chocolate Chip (Large),22 fl oz cup,760,95,200,111
+Smoothies & Shakes,Blueberry Pomegranate Smoothie (Small),12 fl oz cup,220,5,40,50
+Smoothies & Shakes,Blueberry Pomegranate Smoothie (Medium),16 fl oz cup,260,5,50,62
+Smoothies & Shakes,Blueberry Pomegranate Smoothie (Large),22 fl oz cup,340,5,65,79
+Smoothies & Shakes,Strawberry Banana Smoothie (Small),12 fl oz cup,210,5,50,47
+Smoothies & Shakes,Strawberry Banana Smoothie (Medium),16 fl oz cup,250,5,60,58
+Smoothies & Shakes,Strawberry Banana Smoothie (Large),22 fl oz cup,330,5,80,74
+Smoothies & Shakes,Mango Pineapple Smoothie (Small),12 fl oz cup,210,5,40,50
+Smoothies & Shakes,Mango Pineapple Smoothie (Medium),16 fl oz cup,260,5,45,61
+Smoothies & Shakes,Mango Pineapple Smoothie (Large),22 fl oz cup,340,5,60,78
+Smoothies & Shakes,Vanilla Shake (Small),12 fl oz cup,530,60,160,86
+Smoothies & Shakes,Vanilla Shake (Medium),16 fl oz cup,660,75,200,109
+Smoothies & Shakes,Vanilla Shake (Large),22 fl oz cup,820,90,260,135
+Smoothies & Shakes,Strawberry Shake (Small),12 fl oz cup,550,60,160,90
+Smoothies & Shakes,Strawberry Shake (Medium),16 fl oz cup,690,75,210,114
+Smoothies & Shakes,Strawberry Shake (Large),22 fl oz cup,850,90,260,140
+Smoothies & Shakes,Chocolate Shake (Small),12 fl oz cup,560,60,240,91
+Smoothies & Shakes,Chocolate Shake (Medium),16 fl oz cup,700,75,300,114
+Smoothies & Shakes,Chocolate Shake (Large),22 fl oz cup,850,85,380,141
+Smoothies & Shakes,Shamrock Shake (Medium),16 fl oz cup,660,75,210,109
+Smoothies & Shakes,Shamrock Shake (Large),22 fl oz cup,820,90,260,135
+Smoothies & Shakes,McFlurry with M&M’s Candies (Small),10.9 oz (310 g),650,50,180,96
+Smoothies & Shakes,McFlurry with M&M’s Candies (Medium),16.2 oz (460 g),930,75,260,139
+Smoothies & Shakes,McFlurry with M&M’s Candies (Snack),7.3 oz (207 g),430,35,120,64
+Smoothies & Shakes,McFlurry with Oreo Cookies (Small),10.1 oz (285 g),510,45,280,80
+Smoothies & Shakes,McFlurry with Oreo Cookies (Medium),13.4 oz (381 g),690,55,380,106
+Smoothies & Shakes,McFlurry with Oreo Cookies (Snack),6.7 oz (190 g),340,30,190,53
+Smoothies & Shakes,McFlurry with Reese's Peanut Butter Cups (Medium),14.2 oz (403 g),810,60,400,114
+Smoothies & Shakes,McFlurry with Reese's Peanut Butter Cups (Snack),7.1 oz (202 g),410,30,200,57

--- a/tests/test_datascience_eda.py
+++ b/tests/test_datascience_eda.py
@@ -76,6 +76,16 @@ def text_df():
 
 
 def verify_plot(plot, plot_fname, tol):
+    """verify plot created using image regression
+    Parameters
+    ----------
+    plot : matplotlib.figure
+        plot generated
+    plot_fname : string
+        name of the filename to save the plot
+    tol : int
+        Tolerance value for compare_images function
+    """
     currentdir = os.path.dirname(
         os.path.abspath(inspect.getfile(inspect.currentframe()))
     )
@@ -431,6 +441,16 @@ def numeric_df():
 
 
 def test_explore_numeric_columns(numeric_df):
+    """tests explore_text_columns function and its exception handling
+    Parameters
+    ----------
+    numeric_df : pandas.DataFrame
+        test numeric data
+    Returns
+    -------
+    None
+    """
+
     # region test invalid inputs
     with raises(TypeError):
         eda.explore_numeric_columns(1)

--- a/tests/test_datascience_eda.py
+++ b/tests/test_datascience_eda.py
@@ -340,68 +340,68 @@ def test_explore_DBSCAN_clustering(df):
     for i in range(n_combs):
         verify_PCA_plot(p_plots[i].figure, f"/DBSCAN_PCA_{n_clusters[i]}")
 
-# def test_explore_text_columns(text_df):
-#     """tests explore_text_columns function and its exception handling
-#     Parameters
-#     ----------
-#     df : pandas.DataFrame
-#         test text data
-#     Returns
-#     -------
-#     None
-#     """
+def test_explore_text_columns(text_df):
+    """tests explore_text_columns function and its exception handling
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        test text data
+    Returns
+    -------
+    None
+    """
 
-#     currentdir = os.path.dirname(
-#         os.path.abspath(inspect.getfile(inspect.currentframe()))
-#     )
+    currentdir = os.path.dirname(
+        os.path.abspath(inspect.getfile(inspect.currentframe()))
+    )
 
-#     with raises(Exception):
-#         eda.explore_text_columns(['test'])
+    with raises(Exception):
+        eda.explore_text_columns(['test'])
 
-#     with raises(Exception):
-#         eda.explore_text_columns(text_df.drop['sms'])
+    with raises(Exception):
+        eda.explore_text_columns(text_df.drop['sms'])
 
-#     with raises(Exception):
-#         eda.explore_text_columns(text_df, 'sms')
+    with raises(Exception):
+        eda.explore_text_columns(text_df, 'sms')
 
-#     with raises(Exception):
-#         eda.explore_text_columns(text_df, ['some_col_name'])
+    with raises(Exception):
+        eda.explore_text_columns(text_df, ['some_col_name'])
 
-#     result = eda.explore_text_columns(text_df)
+    result = eda.explore_text_columns(text_df)
 
-#     assert(result[0]==['sms'])
+    assert(result[0]==['sms'])
 
-#     assert(result[1]==[80.12, 61, 910, text_df['sms'][1084], 2, text_df['sms'][1924]])
+    assert(result[1]==[80.12, 61, 910, text_df['sms'][1084], 2, text_df['sms'][1924]])
 
-#     verify_plot(result[2].figure, "hist_char_length", 0)
+    verify_plot(result[2].figure, "hist_char_length", 0)
 
-#     assert(result[3]==[15.49, 12, 171, text_df['sms'][1084]])
+    assert(result[3]==[15.49, 12, 171, text_df['sms'][1084]])
 
-#     verify_plot(result[4].figure, "hist_word_count", 0)
+    verify_plot(result[4].figure, "hist_word_count", 0)
 
-#     verify_plot(result[5].figure, "word_cloud", 0)
+    verify_plot(result[5].figure, "word_cloud", 0)
 
-#     verify_plot(result[6].figure, "stopword", 0)
+    verify_plot(result[6].figure, "stopword", 0)
 
-#     verify_plot(result[7].figure, "non_stopword", 0)
+    verify_plot(result[7].figure, "non_stopword", 0)
 
-#     verify_plot(result[8].figure, "bi_gram", 0)
+    verify_plot(result[8].figure, "bi_gram", 0)
 
-#     verify_plot(result[9].figure, "polarity_scores", 0)
+    verify_plot(result[9].figure, "polarity_scores", 0)
 
-#     verify_plot(result[10].figure, "sentiment", 0)
+    verify_plot(result[10].figure, "sentiment", 0)
 
-#     verify_plot(result[11].figure, "subjectivity", 0)
+    verify_plot(result[11].figure, "subjectivity", 0)
 
-#     verify_plot(result[12].figure, "entity", 0)
+    verify_plot(result[12].figure, "entity", 0)
 
-#     verify_plot(result[13].figure, "entity_token_1", 0)
+    verify_plot(result[13].figure, "entity_token_1", 0)
 
-#     verify_plot(result[14].figure, "entity_token_2", 0)
+    verify_plot(result[14].figure, "entity_token_2", 0)
 
-#     verify_plot(result[15].figure, "entity_token_3", 0)
+    verify_plot(result[15].figure, "entity_token_3", 0)
 
-#     verify_plot(result[16].figure, "pos_plot", 0)
+    verify_plot(result[16].figure, "pos_plot", 0)
 
 @pytest.fixture
 def numeric_df():


### PR DESCRIPTION
I have implemented `explore_numeric_columns` function and added tests for it in `test_datascience_eda.py`.

Few important notes:

- I added altair to the .toml file since i am using it. I updated poetry and hence the lock file has also been updated
- Regarding testing the plots, I spoke to Tiff yesterday and she said that - since its difficult to convert altair plots to png, it is okay if i just test for the labels and marks of the graph.

@charlessuresh , please review and let me know if something seems off