### PR TITLE
change dependencies for nltk and en_core_web_md

### DIFF
--- a/datascience_eda/datascience_eda.py
+++ b/datascience_eda/datascience_eda.py
@@ -1,9 +1,9 @@
 from nltk.corpus import stopwords
 from IPython.display import Markdown, display
 from wordcloud import WordCloud
+import spacy.cli
 from sklearn.feature_extraction.text import CountVectorizer
 from textblob import TextBlob
-import en_core_web_md
 from collections import Counter
 from sklearn.cluster import DBSCAN, KMeans
 from sklearn.decomposition import PCA
@@ -16,10 +16,10 @@ import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
 
-
 import nltk
-
 nltk.download("stopwords")
+spacy.cli.download("en_core_web_md")
+import en_core_web_md
 
 
 # region support functions

--- a/datascience_eda/datascience_eda.py
+++ b/datascience_eda/datascience_eda.py
@@ -17,10 +17,14 @@ import seaborn as sns
 import matplotlib.pyplot as plt
 
 import nltk
-nltk.download("stopwords")
-spacy.cli.download("en_core_web_md")
-import en_core_web_md
 
+try:
+    import en_core_web_md
+except ImportError:
+    spacy.cli.download("en_core_web_md")
+    import en_core_web_md
+
+nltk.download("stopwords")
 
 # region support functions
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -295,6 +295,7 @@ spacy = ">=3.0.0,<3.1.0"
 [package.source]
 type = "url"
 url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.0.0/en_core_web_md-3.0.0.tar.gz"
+
 [[package]]
 name = "entrypoints"
 version = "0.3"
@@ -767,7 +768,6 @@ description = "Natural Language Toolkit"
 category = "main"
 optional = false
 python-versions = "*"
-develop = false
 
 [package.dependencies]
 click = "*"
@@ -776,18 +776,12 @@ regex = "*"
 tqdm = "*"
 
 [package.extras]
-all = ["python-crfsuite", "gensim", "pyparsing", "numpy", "scipy", "matplotlib", "scikit-learn", "twython", "requests"]
+all = ["requests", "numpy", "python-crfsuite", "scikit-learn", "twython", "pyparsing", "scipy", "matplotlib", "gensim"]
 corenlp = ["requests"]
 machine_learning = ["gensim", "numpy", "python-crfsuite", "scikit-learn", "scipy"]
 plot = ["matplotlib"]
 tgrep = ["pyparsing"]
 twitter = ["twython"]
-
-[package.source]
-type = "git"
-url = "https://github.com/nltk/nltk.git"
-reference = "3.5"
-resolved_reference = "6404712d0a64c3d6e3700032c23a59803615460c"
 
 [[package]]
 name = "notebook"
@@ -1861,7 +1855,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "8dce61ae2d35c81aafb765d3e05f493b9f861bcf1b4cc30ad321f2de4f39c831"
+content-hash = "d8e30c3b7d7f999046465a007ac3fd34af9764514a84f6ec2f4f3f951f65771d"
 
 [metadata.files]
 alabaster = [
@@ -2366,7 +2360,9 @@ nest-asyncio = [
     {file = "nest_asyncio-1.5.1-py3-none-any.whl", hash = "sha256:76d6e972265063fe92a90b9cc4fb82616e07d586b346ed9d2c89a4187acea39c"},
     {file = "nest_asyncio-1.5.1.tar.gz", hash = "sha256:afc5a1c515210a23c461932765691ad39e8eba6551c055ac8d5546e69250d0aa"},
 ]
-nltk = []
+nltk = [
+    {file = "nltk-3.5.zip", hash = "sha256:845365449cd8c5f9731f7cb9f8bd6fd0767553b9d53af9eb1b3abf7700936b35"},
+]
 notebook = [
     {file = "notebook-6.2.0-py3-none-any.whl", hash = "sha256:25ad93c982b623441b491e693ef400598d1a46cdf11b8c9c0b3be6c61ebbb6cd"},
     {file = "notebook-6.2.0.tar.gz", hash = "sha256:0464b28e18e7a06cec37e6177546c2322739be07962dd13bf712bcb88361f013"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -282,21 +282,6 @@ python-versions = "*"
 setuptools_scm = "*"
 
 [[package]]
-name = "en-core-web-md"
-version = "3.0.0"
-description = "English pipeline optimized for CPU. Components: tok2vec, tagger, parser, senter, ner, attribute_ruler, lemmatizer."
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-spacy = ">=3.0.0,<3.1.0"
-
-[package.source]
-type = "url"
-url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.0.0/en_core_web_md-3.0.0.tar.gz"
-
-[[package]]
 name = "entrypoints"
 version = "0.3"
 description = "Discover and load entry points from installed packages."
@@ -1855,7 +1840,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "d8e30c3b7d7f999046465a007ac3fd34af9764514a84f6ec2f4f3f951f65771d"
+content-hash = "a00024d06c63103911cb0258ac69743f9a91bf3858b185c45ea8657a5fe87dad"
 
 [metadata.files]
 alabaster = [
@@ -2099,7 +2084,6 @@ docutils = [
 dotty-dict = [
     {file = "dotty_dict-1.3.0.tar.gz", hash = "sha256:eb0035a3629ecd84397a68f1f42f1e94abd1c34577a19cd3eacad331ee7cbaf0"},
 ]
-en-core-web-md = []
 entrypoints = [
     {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
     {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,15 +11,14 @@ pandas = "^1.2.2"
 sklearn = "^0.0"
 yellowbrick = "^1.3.post1"
 spacy = "^3.0.3"
-nltk = {git = "https://github.com/nltk/nltk.git", rev = "3.5"}
 seaborn = "^0.11.1"
 ipython = "^7.21.0"
 textblob = "^0.15.3"
-en-core-web-md = {url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.0.0/en_core_web_md-3.0.0.tar.gz"}
 pytest = "^6.2.2"
 wordcloud = "^1.8.1"
 jupyter = "^1.0.0"
 altair = "^4.1.0"
+nltk = "^3.5"
 
 [tool.poetry.dev-dependencies]
 pytest-cov = "^2.11.1"


### PR DESCRIPTION
To try and resolve errors that occur when publishing to pypi, I've done the following:
- changed `nltk` dependency from url install to normal install
- removed `en_core_web_md` model dependency from poetry
- `en_core_web_md` is now downloaded in `datascience_eda.py` using `spacy.cli` 

@rahulkuriyedath @lephanthuymai 
Please review